### PR TITLE
Fix collection duplicates for config persistor

### DIFF
--- a/Collection/Collection.php
+++ b/Collection/Collection.php
@@ -109,14 +109,17 @@ class Collection
     public static function array_merge_assoc_recursive($array1, $array2)
     {
         foreach ($array2 as $key => $value) {
-            if (is_int($key)) {
+
+            if (is_int($key) && !in_array($array2[$key], $array1, true)) {
                 $array1[] = $array2[$key];
             } elseif (!array_key_exists($key, $array1)) {
                 $array1[$key] = $value;
             } elseif (is_array($value) && is_array($array1[$key]) ) {
                 $array1[$key] = self::array_merge_assoc_recursive($array1[$key], $value);
             } else {
-                $array1[$key] = $value;
+                if (!in_array($value, $array1, true)) {
+                    $array1[$key] = $value;
+                }
             }
         }
 

--- a/Tests/CollectionTest.php
+++ b/Tests/CollectionTest.php
@@ -255,10 +255,16 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
                 1 => ['name' => 'Charles', 'role' => 'lead developper'],
                 2 => ['name' => 'Eric', 'role' => 'developper'],
                 3 => 'Florian',
+                4 => 'Alex',
+
             ],
             'foo' => 'bar',
             'bar' => ['foo'],
             'back' => 'bee',
+            'frameworks' => [
+                1 => [1 => 'Rails', 2 => 'ruby'],
+                2 => [1 => 'Symfony', 2 => 'php'],
+            ],
         ];
         $users2 = [
             0 => 'Djoudi',
@@ -266,23 +272,35 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
                 1 => 'Mickael',
                 2 => ['name' => 'Harris', 'role' => 'developper'],
                 3 => ['name' => 'Nicolas', 'role' => 'developper'],
+                4 => 'Florian',
             ],
             'foo' => 'foo',
             'bar' => 'bar',
             'back' => ['bee'],
+            'frameworks' => [
+                1 => [1 => 'Django', 2 => 'python'],
+                2 => [1 => 'Symfony', 2 => 'php'],
+            ],
         ];
         $mergedUsers = [
             'users' => [
                 1 => ['name' => 'Charles', 'role' => 'lead developper'],
                 2 => ['name' => 'Eric', 'role' => 'developper'],
                 3 => 'Florian',
-                4 => 'Mickael',
-                5 => ['name' => 'Harris', 'role' => 'developper'],
-                6 => ['name' => 'Nicolas', 'role' => 'developper'],
+                4 => 'Alex',
+                5 => 'Mickael',
+                6 => ['name' => 'Harris', 'role' => 'developper'],
+                7 => ['name' => 'Nicolas', 'role' => 'developper'],
+                
             ],
             'foo' => 'foo',
             'bar' => 'bar',
             'back' => ['bee'],
+            'frameworks' => [
+                1 => [1 => 'Rails', 2 => 'ruby'],
+                2 => [1 => 'Symfony', 2 => 'php'],
+                3 => [1 => 'Django', 2 => 'python'],
+            ],
             0 => 'Djoudi',
         ];
 


### PR DESCRIPTION
The config persistor duplicate some entries (ex. events in a Bundle config).
Pending a correction on the config persistor, this fix prevents the creation of duplicates.

Thanks.