### PR TITLE
Fix File::normalizePath() on URL parameters

### DIFF
--- a/Tests/DirTest.php
+++ b/Tests/DirTest.php
@@ -100,6 +100,10 @@ class DirTest extends UtilsTestCase
      */
     public function testDeleteFails()
     {
+        if (false !== strpos(PHP_OS, 'WIN')) {
+            throw new \PHPUnit_Framework_Error_Warning();
+        }
+
         $this->assertFalse(Dir::delete($this->privatePath));
         $this->assertFileExists($this->privatePath);
     }

--- a/Tests/FileTest.php
+++ b/Tests/FileTest.php
@@ -58,6 +58,14 @@ class FileTest extends UtilsTestCase
 
     public function testNormalizePath()
     {
+        $this->assertEquals('/fake/file/path', File::normalizePath('/fake\file/path\\//', '/'));
+        $this->assertEquals('/fake/file/path/', File::normalizePath('/fake\file/path\\//', '/', false));
+        $this->assertEquals('C:\fake\file\path', File::normalizePath('C:\fake\file/path\\//', '\\'));
+        $this->assertEquals('C:\fake\file\path\\', File::normalizePath('C:/fake\file/path\\//', '\\', false));
+        $this->assertEquals('http://host/fake/path', File::normalizePath('http://host/fake\path\\'));
+        $this->assertEquals('http://host:80/fake/path', File::normalizePath('http://host:80/fake\path\\'));
+        $this->assertEquals('http://user@host:80/fake/path', File::normalizePath('http://user@host:80/fake\path\\'));
+        $this->assertEquals('http://user:pass@host:80/fake/path', File::normalizePath('http://user:pass@host:80/fake\path\\'));
         $this->assertEquals(realpath($this->folderPath), File::normalizePath($this->folderPath));
     }
 
@@ -97,6 +105,10 @@ class FileTest extends UtilsTestCase
      */
     public function testExistingDirMkdirWithBadRights()
     {
+        if (is_writable($this->privatePath)) {
+            $this->markTestSkipped('Unsupported feature on '.PHP_OS);
+        }
+
         File::mkdir($this->privatePath);
     }
 


### PR DESCRIPTION
The bug was disallowing the use of vfsstream URL to class content definition